### PR TITLE
Add Bash requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 * Because, I didn't want runtime dependency such as Ruby interpreter just to manage my tmux sessions.
 * Shell scripting is free and native, lets do more of that.
 
+## Requirements
+- bash >= 4.x
+
 ## Installation
 
 Copy paste this in your terminal


### PR DESCRIPTION
Adds a Bash requirement to the README to prevent potential issues with macOS users in the future. I wrote this on the linked issue, but macOS ships with a very old version of Bash, which doesn't include the `-A` flag for the `declare` command.

Ref #3 